### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Perfect for web automation, testing, and debugging workflows with AI assistants 
 - **GitHub Copilot Chat** - Enhance your development workflow with browser automation
 - **Any MCP-compatible AI assistant** - Universal browser automation for AI tools
 
+<a href="https://glama.ai/mcp/servers/@Wladastic/AutoProbeMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Wladastic/AutoProbeMCP/badge" alt="AutoProbeMCP MCP server" />
+</a>
+
 ## Features
 
 - **Multi-browser support**: Chromium, Firefox, and WebKit


### PR DESCRIPTION
This PR adds a badge for the [AutoProbeMCP](https://glama.ai/mcp/servers/@Wladastic/AutoProbeMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Wladastic/AutoProbeMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Wladastic/AutoProbeMCP/badge" alt="AutoProbeMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.